### PR TITLE
Rust bindings enhancement

### DIFF
--- a/python-impl/op_swu_g2.py
+++ b/python-impl/op_swu_g2.py
@@ -23,6 +23,7 @@ from fields import Fq, Fq2, roots_of_unity
 from hash_to_field import Hp2
 from typing import Union
 
+
 def sgn0(x: Fq2) -> int:
     # https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-07#section-4.1
 

--- a/python-impl/op_swu_g2.py
+++ b/python-impl/op_swu_g2.py
@@ -198,7 +198,7 @@ def iso3(P):
 #
 # map from Fq2 element(s) to point in G2 subgroup of Ell2
 #
-def opt_swu2_map(t: Fq2, t2: Fq2 = None) -> JacobianPoint:
+def opt_swu2_map(t: Fq2, t2: Fq2 | None = None) -> JacobianPoint:
     Pp = iso3(osswu2_help(t))
     if t2 is not None:
         Pp2 = iso3(osswu2_help(t2))

--- a/python-impl/op_swu_g2.py
+++ b/python-impl/op_swu_g2.py
@@ -198,7 +198,7 @@ def iso3(P):
 #
 # map from Fq2 element(s) to point in G2 subgroup of Ell2
 #
-def opt_swu2_map(t: Fq2, t2: Fq2 | None = None) -> JacobianPoint:
+def opt_swu2_map(t: Fq2, t2: Union[Fq2, None] = None) -> JacobianPoint:
     Pp = iso3(osswu2_help(t))
     if t2 is not None:
         Pp2 = iso3(osswu2_help(t2))

--- a/python-impl/op_swu_g2.py
+++ b/python-impl/op_swu_g2.py
@@ -21,7 +21,7 @@ from bls12381 import h_eff, q
 from ec import JacobianPoint, default_ec_twist, eval_iso
 from fields import Fq, Fq2, roots_of_unity
 from hash_to_field import Hp2
-
+from typing import Union
 
 def sgn0(x: Fq2) -> int:
     # https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-07#section-4.1

--- a/rust-bindings/bls-dash-sys/Cargo.toml
+++ b/rust-bindings/bls-dash-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bls-dash-sys"
 description = ""
-version = "1.2.4"
+version = "1.2.5"
 build = "build.rs"
 edition = "2021"
 

--- a/rust-bindings/bls-dash-sys/bindings.rs
+++ b/rust-bindings/bls-dash-sys/bindings.rs
@@ -386,6 +386,7 @@ extern "C" {
 
     pub fn BIP32ExtendedPrivateKeyFromSeed(
         data: *const ::std::os::raw::c_void,
+        len: usize,
         didErr: *mut bool,
     ) -> BIP32ExtendedPrivateKey;
 

--- a/rust-bindings/bls-dash-sys/bindings.rs
+++ b/rust-bindings/bls-dash-sys/bindings.rs
@@ -67,7 +67,7 @@ extern "C" {
         didErr: *mut bool,
     ) -> PrivateKey;
 
-    pub fn PrivateKeyFromSeedBIP32(data: *const ::std::os::raw::c_void) -> PrivateKey;
+    pub fn PrivateKeyFromSeedBIP32(data: *const ::std::os::raw::c_void, len: usize) -> PrivateKey;
 
     pub fn PrivateKeyAggregate(sks: *mut *mut ::std::os::raw::c_void, len: usize) -> PrivateKey;
 

--- a/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedprivatekey.cpp
+++ b/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedprivatekey.cpp
@@ -21,12 +21,12 @@ BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromBytes(const void* data, bool*
     return el;
 }
 
-BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromSeed(const void* data, bool* didErr)
+BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromSeed(const void* data, const size_t len, bool* didErr)
 {
     bls::ExtendedPrivateKey* el = nullptr;
     try {
         el = new bls::ExtendedPrivateKey(bls::ExtendedPrivateKey::FromSeed(
-            bls::Bytes((uint8_t*)(data), bls::ExtendedPrivateKey::SIZE)));
+            bls::Bytes((uint8_t*)(data), len)));
     } catch (const std::exception& ex) {
         gErrMsg = ex.what();
         *didErr = true;

--- a/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedprivatekey.h
+++ b/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedprivatekey.h
@@ -19,7 +19,7 @@ typedef void* BIP32ExtendedPrivateKey;
 BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromBytes(
     const void* data,
     bool* didErr);
-BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromSeed(const void* data, bool* didErr);
+BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromSeed(const void* data, const size_t len, bool* didErr);
 BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyPrivateChild(
     const BIP32ExtendedPrivateKey sk,
     const uint32_t index,

--- a/rust-bindings/bls-dash-sys/c-bindings/privatekey.cpp
+++ b/rust-bindings/bls-dash-sys/c-bindings/privatekey.cpp
@@ -39,11 +39,9 @@ PrivateKey PrivateKeyFromBytes(const void* data, const bool modOrder, bool* didE
     return skPtr;
 }
 
-PrivateKey PrivateKeyFromSeedBIP32(const void* data) {
+PrivateKey PrivateKeyFromSeedBIP32(const void* data, const size_t len) {
     return new bls::PrivateKey(
-        bls::PrivateKey::FromSeedBIP32(
-            bls::Bytes((uint8_t*)data, bls::PrivateKey::PRIVATE_KEY_SIZE)
-        )
+        bls::PrivateKey::FromSeedBIP32(bls::Bytes((uint8_t*)data, len))
     );
 }
 

--- a/rust-bindings/bls-dash-sys/c-bindings/privatekey.h
+++ b/rust-bindings/bls-dash-sys/c-bindings/privatekey.h
@@ -24,7 +24,7 @@ extern "C" {
 typedef void* PrivateKey;
 
 PrivateKey PrivateKeyFromBytes(const void* data, const bool modOrder, bool* didErr);
-PrivateKey PrivateKeyFromSeedBIP32(const void* data);
+PrivateKey PrivateKeyFromSeedBIP32(const void* data, const size_t len);
 PrivateKey PrivateKeyAggregate(void** sks, const size_t len);
 G1Element PrivateKeyGetG1Element(const PrivateKey sk, bool* didErr);
 G2Element PrivateKeyGetG2Element(const PrivateKey sk, bool* didErr);

--- a/rust-bindings/bls-dash-sys/tests/sign_and_verify.rs
+++ b/rust-bindings/bls-dash-sys/tests/sign_and_verify.rs
@@ -55,3 +55,25 @@ fn sign_and_verify() {
         sys::AugSchemeMPLFree(scheme);
     }
 }
+
+#[test]
+fn test_private_key_from_bip32() {
+    use std::slice;
+    let long_seed: [u8; 32] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2];
+    let long_private_key_test_data: [u8; 32] = [50, 67, 148, 112, 207, 6, 210, 118, 137, 125, 27, 144, 105, 189, 214, 228, 68, 83, 144, 205, 80, 105, 133, 222, 14, 26, 28, 136, 167, 111, 241, 118];
+    let short_seed: [u8; 10] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let short_private_key_test_data: [u8; 32] = [70, 137, 28, 44, 236, 73, 89, 60, 129, 146, 30, 71, 61, 183, 72, 0, 41, 224, 252, 30, 185, 51, 198, 185, 61, 129, 245, 55, 14, 177, 159, 189];
+    unsafe {
+        let c_private_key = sys::PrivateKeyFromSeedBIP32(long_seed.as_ptr() as *const _, long_seed.len());
+        let serialized = sys::PrivateKeySerialize(c_private_key) as *const u8;
+        let data = slice::from_raw_parts(serialized, sys::PrivateKeySizeBytes());
+        assert_eq!(data, &long_private_key_test_data);
+        sys::PrivateKeyFree(c_private_key);
+
+        let c_private_key = sys::PrivateKeyFromSeedBIP32(short_seed.as_ptr() as *const _, short_seed.len());
+        let serialized = sys::PrivateKeySerialize(c_private_key) as *const u8;
+        let data = slice::from_raw_parts(serialized, sys::PrivateKeySizeBytes());
+        assert_eq!(data, &short_private_key_test_data);
+        sys::PrivateKeyFree(c_private_key);
+    }
+}

--- a/rust-bindings/bls-signatures/Cargo.toml
+++ b/rust-bindings/bls-signatures/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bls-signatures"
 description = ""
-version = "1.2.4"
+version = "1.2.5"
 edition = "2021"
 
 [features]

--- a/rust-bindings/bls-signatures/src/bip32/private_key.rs
+++ b/rust-bindings/bls-signatures/src/bip32/private_key.rs
@@ -190,4 +190,13 @@ mod tests {
 
         assert_eq!(private_key.public_key(), Ok(public_key.public_key()));
     }
+
+    #[test]
+    fn fingerprint_for_short_bip32_seed() {
+        assert_eq!(ExtendedPrivateKey::from_seed(&[1u8, 50, 6, 244, 24, 199, 1, 25])
+            .expect("cannot generate extended private key")
+            .public_key()
+            .expect("cannot get public key from extended private key")
+            .fingerprint_legacy(), 0xa4700b27);
+    }
 }

--- a/rust-bindings/bls-signatures/src/bip32/private_key.rs
+++ b/rust-bindings/bls-signatures/src/bip32/private_key.rs
@@ -55,7 +55,7 @@ impl ExtendedPrivateKey {
     pub fn from_seed(bytes: &[u8]) -> Result<Self, BlsError> {
         Ok(ExtendedPrivateKey {
             c_extended_private_key: c_err_to_result(|did_err| unsafe {
-                BIP32ExtendedPrivateKeyFromSeed(bytes.as_ptr() as *const _, did_err)
+                BIP32ExtendedPrivateKeyFromSeed(bytes.as_ptr() as *const _, bytes.len(), did_err)
             })?,
         })
     }

--- a/rust-bindings/bls-signatures/src/private_key.rs
+++ b/rust-bindings/bls-signatures/src/private_key.rs
@@ -30,7 +30,7 @@ impl Mul<G1Element> for PrivateKey {
     fn mul(self, rhs: G1Element) -> Self::Output {
         Ok(G1Element {
             c_element: c_err_to_result(|did_err| unsafe {
-                G1ElementMul(self.c_private_key, rhs.c_element)
+                G1ElementMul(rhs.c_element, self.c_private_key)
             })?,
         })
     }

--- a/rust-bindings/bls-signatures/src/private_key.rs
+++ b/rust-bindings/bls-signatures/src/private_key.rs
@@ -1,10 +1,7 @@
 use std::ffi::c_void;
+use std::ops::Mul;
 
-use bls_dash_sys::{
-    CoreMPLDeriveChildSk, CoreMPLDeriveChildSkUnhardened, CoreMPLKeyGen, PrivateKeyFree,
-    PrivateKeyFromBytes, PrivateKeyFromSeedBIP32, PrivateKeyGetG1Element, PrivateKeyIsEqual,
-    PrivateKeySerialize,
-};
+use bls_dash_sys::{CoreMPLDeriveChildSk, CoreMPLDeriveChildSkUnhardened, CoreMPLKeyGen, G1ElementMul, PrivateKeyFree, PrivateKeyFromBytes, PrivateKeyFromSeedBIP32, PrivateKeyGetG1Element, PrivateKeyIsEqual, PrivateKeySerialize};
 
 use crate::{
     schemes::Scheme,

--- a/rust-bindings/bls-signatures/src/private_key.rs
+++ b/rust-bindings/bls-signatures/src/private_key.rs
@@ -27,6 +27,18 @@ impl PartialEq for PrivateKey {
 
 impl Eq for PrivateKey {}
 
+impl Mul<G1Element> for PrivateKey {
+    type Output = Result<G1Element, BlsError>;
+
+    fn mul(self, rhs: G1Element) -> Self::Output {
+        Ok(G1Element {
+            c_element: c_err_to_result(|did_err| unsafe {
+                G1ElementMul(self.c_private_key, rhs.c_element)
+            })?,
+        })
+    }
+}
+
 impl PrivateKey {
     pub(crate) fn as_mut_ptr(&self) -> *mut c_void {
         self.c_private_key

--- a/rust-bindings/bls-signatures/src/private_key.rs
+++ b/rust-bindings/bls-signatures/src/private_key.rs
@@ -105,7 +105,7 @@ impl PrivateKey {
     }
 
     pub fn from_bip32_seed(bytes: &[u8]) -> Self {
-        let c_private_key = unsafe { PrivateKeyFromSeedBIP32(bytes.as_ptr() as *const c_void) };
+        let c_private_key = unsafe { PrivateKeyFromSeedBIP32(bytes.as_ptr() as *const c_void, bytes.len()) };
 
         PrivateKey { c_private_key }
     }
@@ -156,16 +156,16 @@ mod tests {
 
     #[test]
     fn should_return_private_key_from_bip32_bytes() {
-        let bytes = [1, 2, 3, 4, 5, 6, 7];
-        let private_key = PrivateKey::from_bip32_seed(&bytes);
-        let expected_key_bytes = [
-            0, 40, 43, 250, 83, 117, 227, 93, 174, 67, 170, 185, 235, 46, 70, 117, 110, 208, 224,
-            23, 164, 13, 180, 200, 132, 46, 57, 21, 207, 149, 248, 135,
-        ];
-        assert_eq!(*private_key.serialize(), expected_key_bytes);
-        let alice_seed = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        let pk1 = PrivateKey::from_bip32_seed(&bytes);
-        let private_key = pk1.serialize();
+        let long_seed = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2];
+        let long_private_key_test_data = [50, 67, 148, 112, 207, 6, 210, 118, 137, 125, 27, 144, 105, 189, 214, 228, 68, 83, 144, 205, 80, 105, 133, 222, 14, 26, 28, 136, 167, 111, 241, 118];
+        let long_private_key = PrivateKey::from_bip32_seed(&long_seed);
+        assert_eq!(*long_private_key.serialize(), long_private_key_test_data);
+
+        // Previously didn't work with seed with length != 32
+        let short_seed = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let short_private_key_test_data = [70, 137, 28, 44, 236, 73, 89, 60, 129, 146, 30, 71, 61, 183, 72, 0, 41, 224, 252, 30, 185, 51, 198, 185, 61, 129, 245, 55, 14, 177, 159, 189];
+        let short_private_key = PrivateKey::from_bip32_seed(&short_seed);
+        assert_eq!(*short_private_key.serialize(), short_private_key_test_data);
     }
 
     #[test]

--- a/rust-bindings/bls-signatures/src/private_key.rs
+++ b/rust-bindings/bls-signatures/src/private_key.rs
@@ -1,7 +1,11 @@
 use std::ffi::c_void;
 use std::ops::Mul;
 
-use bls_dash_sys::{CoreMPLDeriveChildSk, CoreMPLDeriveChildSkUnhardened, CoreMPLKeyGen, G1ElementMul, PrivateKeyFree, PrivateKeyFromBytes, PrivateKeyFromSeedBIP32, PrivateKeyGetG1Element, PrivateKeyIsEqual, PrivateKeySerialize};
+use bls_dash_sys::{
+    CoreMPLDeriveChildSk, CoreMPLDeriveChildSkUnhardened, CoreMPLKeyGen, G1ElementMul,
+    PrivateKeyFree, PrivateKeyFromBytes, PrivateKeyFromSeedBIP32, PrivateKeyGetG1Element,
+    PrivateKeyIsEqual, PrivateKeySerialize,
+};
 
 use crate::{
     schemes::Scheme,
@@ -153,37 +157,50 @@ mod tests {
     #[test]
     fn should_return_private_key_from_bip32_bytes() {
         let bytes = [1, 2, 3, 4, 5, 6, 7];
-
         let private_key = PrivateKey::from_bip32_seed(&bytes);
-
         let expected_key_bytes = [
             0, 40, 43, 250, 83, 117, 227, 93, 174, 67, 170, 185, 235, 46, 70, 117, 110, 208, 224,
             23, 164, 13, 180, 200, 132, 46, 57, 21, 207, 149, 248, 135,
         ];
-
         assert_eq!(*private_key.serialize(), expected_key_bytes);
+        let alice_seed = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let pk1 = PrivateKey::from_bip32_seed(&bytes);
+        let private_key = pk1.serialize();
     }
 
     #[test]
     fn test_keys_multiplication() {
         //46891c2cec49593c81921e473db7480029e0fc1eb933c6b93d81f5370eb19fbd
-        let private_key_data = [70, 137, 28, 44, 236, 73, 89, 60, 129, 146, 30, 71, 61, 183, 72, 0,
-            41, 224, 252, 30, 185, 51, 198, 185, 61, 129, 245, 55, 14, 177, 159, 189];
+        let private_key_data = [
+            70, 137, 28, 44, 236, 73, 89, 60, 129, 146, 30, 71, 61, 183, 72, 0, 41, 224, 252, 30,
+            185, 51, 198, 185, 61, 129, 245, 55, 14, 177, 159, 189,
+        ];
         //0e2f9055c17eb13221d8b41833468ab49f7d4e874ddf4b217f5126392a608fd48ccab3510548f1da4f397c1ad4f8e01a
-        let public_key_data = [14, 47, 144, 85, 193, 126, 177, 50, 33, 216, 180, 24, 51, 70, 138,
-            180, 159, 125, 78, 135, 77, 223, 75, 33, 127, 81, 38, 57, 42, 96, 143, 212, 140, 202,
-            179, 81, 5, 72, 241, 218, 79, 57, 124, 26, 212, 248, 224, 26];
+        let public_key_data = [
+            14, 47, 144, 85, 193, 126, 177, 50, 33, 216, 180, 24, 51, 70, 138, 180, 159, 125, 78,
+            135, 77, 223, 75, 33, 127, 81, 38, 57, 42, 96, 143, 212, 140, 202, 179, 81, 5, 72, 241,
+            218, 79, 57, 124, 26, 212, 248, 224, 26,
+        ];
         //03fd387c4d4c66ec9dcdb31ef0c08ad881090dcda13d4b2c9cbc5ef264ff4dc7
-        let expected_data = [3, 253, 56, 124, 77, 76, 102, 236, 157, 205, 179, 30, 240, 192, 138,
-            216, 129, 9, 13, 205, 161, 61, 75, 44, 156, 188, 94, 242, 100, 255, 77, 199];
+        let expected_data = [
+            3, 253, 56, 124, 77, 76, 102, 236, 157, 205, 179, 30, 240, 192, 138, 216, 129, 9, 13,
+            205, 161, 61, 75, 44, 156, 188, 94, 242, 100, 255, 77, 199,
+        ];
         let private_key = PrivateKey::from_bytes(&private_key_data, false).unwrap();
         let public_key = G1Element::from_bytes_legacy(&public_key_data).unwrap();
         let result = (private_key * public_key).unwrap();
-        assert_eq!(&result.serialize_legacy()[..32], &expected_data, "should match");
+        assert_eq!(
+            &result.serialize_legacy()[..32],
+            &expected_data,
+            "should match"
+        );
         let private_key = PrivateKey::from_bytes(&private_key_data, false).unwrap();
         let public_key = G1Element::from_bytes_legacy(&public_key_data).unwrap();
         let result = (public_key * private_key).unwrap();
-        assert_eq!(&result.serialize_legacy()[..32], &expected_data, "should match");
+        assert_eq!(
+            &result.serialize_legacy()[..32],
+            &expected_data,
+            "should match"
+        );
     }
-
 }


### PR DESCRIPTION
Implement multiplication for PrivateKey * G1Element
Fix PrivateKeyFromSeedBIP32 for seeds with arbitrary lengths (previously the lib treated all seeds as if their length was 32)
Add corresponding tests